### PR TITLE
Fixed problem with long CData strings

### DIFF
--- a/src/spi/binary/__init__.py
+++ b/src/spi/binary/__init__.py
@@ -672,13 +672,13 @@ class CData:
             bits += tmp
         elif datalength >= 254 and datalength <= 1<<16:
             tmp = bitarray()
-            tmp.fromstring('\xfe')
+            tmp.frombytes'\xfe')
             bits += tmp
             tmp = encode_number(datalength, 16)
             bits += tmp
         elif datalength > 1<<16 and datalength <= 1<<24: 
             tmp = bitarray()
-            tmp.fromstring('\xff')
+            tmp.frombytes('\xff')
             bits += tmp
             tmp = encode_number(datalength, 24)
             bits += tmp


### PR DESCRIPTION
CData strings longer than 253 bytes were failing to encode