### PR TITLE
Correct encoding of serviceInformation language

### DIFF
--- a/src/spi/binary/__init__.py
+++ b/src/spi/binary/__init__.py
@@ -814,11 +814,11 @@ def build_time(time):
     if isinstance(time, Time):
         time_element = Element(0x2c)
         time_element.attributes.append(Attribute(0x80, time.billed_time, encode_timepoint))
+        time_element.attributes.append(Attribute(0x81, time.billed_duration.seconds, encode_number, 16))
         if time.actual_time is not None:
             time_element.attributes.append(Attribute(0x82, time.actual_time, encode_timepoint))
         if time.actual_duration is not None:
-            time_element.attributes.append(Attribute(0x83, time.actual_duration.seconds, encode_number, 16))            
-        time_element.attributes.append(Attribute(0x81, time.billed_duration.seconds, encode_number, 16))
+            time_element.attributes.append(Attribute(0x83, time.actual_duration.seconds, encode_number, 16))
     elif isinstance(time, RelativeTime):
         time_element = Element(0x2f)
         time_element.attributes.append(Attribute(0x80, time.billed_offset.seconds, encode_number, 16))

--- a/src/spi/test/BearerTest.py
+++ b/src/spi/test/BearerTest.py
@@ -1,0 +1,16 @@
+from spi import *
+
+import unittest
+
+class BearerTest(unittest.TestCase):
+
+    def test_fm_parse_valid(self):
+        print('here')
+        FmBearer.fromstring('fm:ce1.c985.09580')
+        FmBearer.fromstring('fm:ce1.c985.*')
+
+    @unittest.expectedFailure
+    def test_fm_parse_invalid(self):
+        FmBearer.fromstring('fm:cee1.c85.095802')
+        FmBearer.fromstring('fm:ce1.*.09580')
+


### PR DESCRIPTION
The encoding of the language of the serviceInformation element has been adjusted to be in line with TS 102 371 (it's no longer an attribute of the element).